### PR TITLE
Bcel Version Update

### DIFF
--- a/Formula/ant.rb
+++ b/Formula/ant.rb
@@ -15,7 +15,7 @@ class Ant < Formula
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.2-bin.tar.gz"
+    url "https://www.apache.org/dyn/closer.cgi?path=commons/bcel/binaries/bcel-6.3-bin.tar.gz"
     sha256 "e5963ed50ef1f243f852a27efaf898c050a3b39721d147ccda8418c0b7255955"
   end
 


### PR DESCRIPTION
It seems bcel version 6.2 is not available anymore. Update it to 6.3.